### PR TITLE
RDSC-4137: Pin postgres Docker image version to 17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres
+FROM postgres:17
 
 COPY scripts/init_docker-postgres.sh /docker-entrypoint-initdb.d/
 


### PR DESCRIPTION
Pin the tag for the base docker image, so we aren't broken by major version upgrades.