### PR TITLE
Fix init script for PostgreSQL 18 compatibility

### DIFF
--- a/scripts/init_docker-postgres.sh
+++ b/scripts/init_docker-postgres.sh
@@ -2,7 +2,6 @@
 
 set -e
 
-PGDATA=/var/lib/postgresql/data
 
 echo "wal_level = logical" >> $PGDATA/postgresql.conf
 


### PR DESCRIPTION
## Fix PostgreSQL 18 Compatibility Issue

### Problem
The initialization script fails on PostgreSQL 18 because it uses a hardcoded path to `postgresql.conf` that doesn't exist:
```bash
PGDATA=/var/lib/postgresql/data
echo "wal_level = logical" >> $PGDATA/postgresql.conf
```

PostgreSQL 18 uses `/var/lib/postgresql/18/docker` instead of `/var/lib/postgresql/data`, causing the script to fail with:
```
/var/lib/postgresql/data/postgresql.conf: No such file or directory
```

This prevents the Chinook database from being initialized and populated.

### Solution
Use the container's `$PGDATA` environment variable instead of hardcoding the path. This makes the script compatible with all PostgreSQL versions.

### Testing
Tested with:
- PostgreSQL 18 (latest) ✅
- Tables are now properly created and populated on first run

### Changes
- Modified `scripts/init_docker-postgres.sh` to use `$PGDATA` environment variable